### PR TITLE
Inhibit updating JUnit to version 6 until Android supports it

### DIFF
--- a/examples/app/build.gradle
+++ b/examples/app/build.gradle
@@ -63,14 +63,14 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.17.0'
 
 
-    testImplementation platform('org.junit:junit-bom:5.14.0')
+    testImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.platform:junit-platform-launcher'
 
     androidTestImplementation 'io.github.neboskreb:android-log4j2-junit5:2.24'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation platform('org.junit:junit-bom:5.14.0')
+    androidTestImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api"
     androidTestImplementation 'org.junit.jupiter:junit-jupiter'
     androidTestImplementation 'org.junit.platform:junit-platform-launcher'

--- a/examples/lib/build.gradle
+++ b/examples/lib/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
 
     testImplementation 'io.github.neboskreb:android-log4j2:2.24'
-    testImplementation platform('org.junit:junit-bom:5.14.0')
+    testImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
@@ -57,7 +57,7 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.7.0'
     androidTestImplementation 'androidx.test:runner:1.7.0'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation platform('org.junit:junit-bom:5.14.0')
+    androidTestImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     androidTestImplementation 'org.junit.jupiter:junit-jupiter-api'
     androidTestImplementation 'org.junit.jupiter:junit-jupiter'
     androidTestImplementation 'org.junit.platform:junit-platform-launcher'

--- a/examples/migration-lib/build.gradle
+++ b/examples/migration-lib/build.gradle
@@ -43,14 +43,14 @@ dependencies {
 
 
     testImplementation 'io.github.neboskreb:android-log4j2:2.24'
-    testImplementation platform('org.junit:junit-bom:5.12.2')
+    testImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
 
 
     androidTestImplementation 'io.github.neboskreb:android-log4j2-junit5:2.24'
-    androidTestImplementation platform('org.junit:junit-bom:5.12.2')
+    androidTestImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     androidTestImplementation 'org.junit.jupiter:junit-jupiter-api'
     androidTestImplementation 'org.junit.jupiter:junit-jupiter'
     androidTestImplementation 'org.junit.platform:junit-platform-launcher'

--- a/junit5/build.gradle
+++ b/junit5/build.gradle
@@ -114,13 +114,13 @@ android {
 dependencies {
     api 'io.github.neboskreb:android-log4j2:2.24'
     compileOnly 'androidx.test.ext:junit:1.3.0'
-    compileOnly platform('org.junit:junit-bom:5.14.0')
+    compileOnly platform('org.junit:junit-bom:[5.14.0, 6.0)')
     compileOnly 'org.junit.jupiter:junit-jupiter-api'
     compileOnly 'org.junit.jupiter:junit-jupiter'
     compileOnly 'org.junit.platform:junit-platform-launcher'
 
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation platform('org.junit:junit-bom:5.14.0')
+    androidTestImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     androidTestImplementation 'org.junit.jupiter:junit-jupiter-api'
     androidTestImplementation 'org.junit.jupiter:junit-jupiter'
     androidTestImplementation 'org.junit.platform:junit-platform-launcher'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     // ==== /Lombok
 
 
-    testImplementation platform('org.junit:junit-bom:5.14.0')
+    testImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly    'org.junit.platform:junit-platform-launcher'
@@ -139,7 +139,7 @@ dependencies {
 
 
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation platform('org.junit:junit-bom:5.14.0')
+    androidTestImplementation platform('org.junit:junit-bom:[5.14.0, 6.0)')
     androidTestImplementation 'org.junit.jupiter:junit-jupiter-api'
     androidTestImplementation 'org.junit.jupiter:junit-jupiter'
     androidTestImplementation 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
Currently JUnit 6 cannot be used on Android because of the parts of Java API which JUnit uses but Android doesn't have. See [discussion here](https://github.com/android/android-test/issues/224#issuecomment-3354119315).